### PR TITLE
Accept luajit version when checking for updates

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -48,11 +48,12 @@ local function check_updates()
 	local raw_data = fetch("https://api.github.com/repos/lite-xl/lite-xl/releases/latest")
 	local data = json.decode(raw_data)
 
-	core.log_quiet(data.tag_name)
-
 	local current_version = "v" .. VERSION
 
-	if current_version == data.tag_name or data.draft or data.prerelease then
+	core.log_quiet("latest: " .. data.tag_name .. " installed: " .. current_version )
+
+	if current_version == data.tag_name or current_version == data.tag_name .. "-luajit"
+			or data.draft or data.prerelease then
 		core.log_quiet("lite-xl is up to date")
 		return
 	end


### PR DESCRIPTION
Previously, this extension showed the "update available" dialogue on every start when using the luajit branch (like for example when using the lite-xl package from the AUR). This small change fixes this by additionally comparing `current_version` with `data.tag_name .. "-luajit"`.
I also changed the log output to include the installed version, instead of just printing the latest version without any hints about the meaning of this log entry.